### PR TITLE
Fix components not being rendered upon changing URI location

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { Component } from 'react'
 import { Switch, Route } from 'react-router-dom'
 
 // import {
@@ -13,7 +13,7 @@ import { Switch, Route } from 'react-router-dom'
 //   Event
 // } from './containers'
 
-export default class Routes extends PureComponent {
+export default class Routes extends Component {
   render() {
     return (
       <Switch>


### PR DESCRIPTION
PureComponent prevents component from re-rendering once URI path changes with <Link> from react-router-dom. It should be Component insteads.