### PR TITLE
Handle category without associated organizations. Fix the view errors.

### DIFF
--- a/src/pages/TopicCardList.js
+++ b/src/pages/TopicCardList.js
@@ -17,23 +17,26 @@ class TopicCardList extends PureComponent {
       const { category } = this.props
       if (category === null) {
         return null
-      // } else if (category.organizations.length > 1) {
-      //   return category.organizations.map(this.renderTopic.bind(this))
+      } else if (category.organizations.length === 0) {
+        return null
       } else {
-        // return this.renderTopic(category.organizations)
         return category.organizations.map(this.renderTopic.bind(this))
       }
     }
 
   /* It should be read from the 'tagline' property in organizations schema */
   renderTopic(topics, index) {
-    return (
-        <Link to={'/organizations/' + topics._id}>
-          <TopicCard
-            key={index}
-            title={topics.about} />
-        </Link>
-    )
+    if (topics === null ) {
+      return null
+    } else {
+      return (
+          <Link to={'/organizations/' + topics._id}>
+            <TopicCard
+              key={index}
+              title={topics.about} />
+          </Link>
+      )
+    }
   }
 
   render() {


### PR DESCRIPTION
Also handle the case when a category does not have any associated organizations.